### PR TITLE
Use YAML / info hook / annotations / something instead of magic naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,27 @@ That class will be discovered and returned by the factory function in
 $typed_entity = TypedEntityManager::create($entity_type, $entity);
 ```
 
+If you don't like the naming convention or you prefer to use something else, you can provide the class for your entity. For that you will have to implement `hook_typed_entity_registry_info`. See [the example](modules/typed_entity_example/typed_entity_example.module).
+
+```php
+/**
+ * Implements hook_module_typed_entity_registry_info().
+ */
+function custom_module_typed_entity_registry_info() {
+  $items['user'] = array(
+    'entity_type' => 'user',
+    'class' => '\Drupal\custom_module\Foo\Bar\User',
+  );
+  $items['file'] = array(
+    'entity_type' => 'file',
+    'bundle' => 'image',
+    'class' => '\Drupal\custom_module\File\Image',
+  );
+
+  return $items;
+}
+```
+
 ### Accessing the underlying entity
 This module uses the PHP magic methods to allow you to do things like:
 

--- a/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleUnitTestCase.php
+++ b/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleUnitTestCase.php
@@ -19,7 +19,7 @@ class TypedEntityExampleUnitTestCase extends \DrupalUnitTestCase {
    */
   public static function getInfo() {
     return array(
-      'name' => 'Typed entity example',
+      'name' => 'Typed entity example (unit)',
       'description' => 'Shows an example of how you can do unit testing of your code.',
       'group' => 'Typed Entity',
     );

--- a/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleWebTestCase.php
+++ b/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleWebTestCase.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\typed_entity_example\Tests\TypedEntityExampleWebTestCase
+ */
+
+namespace Drupal\typed_entity_example\Tests;
+
+use Drupal\typed_entity\TypedEntity\TypedEntity;
+use Drupal\typed_entity\TypedEntity\TypedEntityManager;
+use Drupal\typed_entity_example\TypedEntity\Node\Article;
+use Drupal\typed_entity_example\TypedEntity\TypedNode;
+
+class TypedEntityExampleWebTestCase extends \DrupalWebTestCase {
+
+  /**
+   * Declare test information.
+   *
+   * @return array
+   *   The information array.
+   */
+  public static function getInfo() {
+    return array(
+      'name' => 'Typed entity example (functional)',
+      'description' => 'Functional tests for Typed Entity.',
+      'group' => 'Typed Entity',
+    );
+  }
+
+  /**
+   * Set up.
+   */
+  protected function setUp() {
+    parent::setUp('typed_entity_example');
+  }
+
+  /**
+   * Test factory.
+   */
+  public function testFactory() {
+    $article = $this->drupalCreateNode(array(
+      'type' => 'article',
+      'title' => 'Test article',
+    ));
+    $typed_article = TypedEntityManager::create('node', $article);
+    if ($typed_article instanceof Article) {
+      $this->pass('The hook_typed_entity_registry_info is taking precedence.');
+    }
+    else {
+      $this->fail('The hook_typed_entity_registry_info is not taking precedence.');
+    }
+
+    // Test the fallback to the TypedNode.
+    $page = $this->drupalCreateNode(array(
+      'type' => 'page',
+      'title' => 'Test article',
+    ));
+    $typed_page = TypedEntityManager::create('node', $page);
+    if ($typed_page instanceof TypedNode) {
+      $this->pass('The factory is falling back to TypedNode.');
+    }
+    else {
+      $this->fail('The factory is not falling back to TypedNode.');
+    }
+
+    // Test the fallback to TypedEntity.
+    $account = $this->drupalCreateUser();
+    $typed_user = TypedEntityManager::create('user', $account);
+    if ($typed_user instanceof TypedEntity) {
+      $this->pass('The factory is falling back to TypedEntity.');
+    }
+    else {
+      $this->fail('The factory is not falling back to TypedEntity.');
+    }
+  }
+
+}

--- a/modules/typed_entity_example/src/TypedEntity/Node/Article.php
+++ b/modules/typed_entity_example/src/TypedEntity/Node/Article.php
@@ -2,15 +2,16 @@
 
 /**
  * @file
- * Contains \Drupal\typed_entity_example\TypedEntity\TypedNodeArticle.
+ * Contains \Drupal\typed_entity_example\TypedEntity\Node\Article.
  */
 
-namespace Drupal\typed_entity_example\TypedEntity;
+namespace Drupal\typed_entity_example\TypedEntity\Node;
 
 use Drupal\typed_entity\TypedEntity\TypedEntityInterface;
 use Drupal\typed_entity\TypedEntity\TypedEntityManager;
+use Drupal\typed_entity_example\TypedEntity\TypedNode;
 
-class TypedNodeArticle extends TypedNode implements TypedNodeArticleInterface {
+class Article extends TypedNode implements ArticleInterface {
 
   /**
    * The article image.

--- a/modules/typed_entity_example/src/TypedEntity/Node/ArticleInterface.php
+++ b/modules/typed_entity_example/src/TypedEntity/Node/ArticleInterface.php
@@ -2,14 +2,15 @@
 
 /**
  * @file
- * Contains \Drupal\typed_entity_example\TypedEntity\TypedNodeArticleInterface.
+ * Contains \Drupal\typed_entity_example\TypedEntity\Node\ArticleInterface.
  */
 
-namespace Drupal\typed_entity_example\TypedEntity;
+namespace Drupal\typed_entity_example\TypedEntity\Node;
 
 use Drupal\typed_entity\TypedEntity\TypedEntityInterface;
+use Drupal\typed_entity_example\TypedEntity\TypedNodeInterface;
 
-interface TypedNodeArticleInterface extends TypedNodeInterface {
+interface ArticleInterface extends TypedNodeInterface {
 
   /**
    * Gets the author of the node.

--- a/modules/typed_entity_example/src/TypedEntity/Tests/TypedNodeArticleUnitTest.php
+++ b/modules/typed_entity_example/src/TypedEntity/Tests/TypedNodeArticleUnitTest.php
@@ -7,9 +7,9 @@
 
 namespace Drupal\typed_entity_example\TypedEntity\Tests;
 
-use Drupal\typed_entity_example\TypedEntity\TypedNodeArticle;
+use Drupal\typed_entity_example\TypedEntity\Node\Article;
 
-class TypedNodeArticleUnitTest extends TypedNodeArticle {
+class TypedNodeArticleUnitTest extends Article {
 
   /**
    * Overrides TypedNodeArticle::t().

--- a/modules/typed_entity_example/typed_entity_example.module
+++ b/modules/typed_entity_example/typed_entity_example.module
@@ -8,6 +8,19 @@
 use Drupal\typed_entity\TypedEntity\TypedEntityManager;
 
 /**
+ * Implements hook_typed_entity_registry_info().
+ */
+function typed_entity_example_typed_entity_registry_info() {
+  $items['article'] = array(
+    'entity_type' => 'node',
+    'bundle' => 'article',
+    'class' => '\\Drupal\\typed_entity_example\\TypedEntity\\Node\\Article',
+  );
+
+  return $items;
+}
+
+/**
  * Implements hook_menu().
  */
 function typed_entity_example_menu() {
@@ -32,7 +45,7 @@ function typed_entity_example_menu() {
  *   The page content.
  */
 function typed_entity_example_node_typed($node) {
-  /** @var \Drupal\typed_entity_example\TypedEntity\TypedNodeArticle $typed_node */
+  /** @var \Drupal\typed_entity_example\TypedEntity\Node\Article $typed_node */
   $typed_node = TypedEntityManager::create('node', $node);
   drupal_set_title($typed_node->title);
 

--- a/typed_entity.api.php
+++ b/typed_entity.api.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Hook documentation file.
+ */
+
+/**
+ * Returns an array with the mappings of the entity type, bundle and classes.
+ *
+ * Use this as an alternative to the naming convention.
+ *
+ * @return array
+ *   The array of items.
+ */
+function hook_typed_entity_registry_info() {
+  $items['user'] = array(
+    'entity_type' => 'user',
+    'class' => '\Drupal\custom_module\Foo\Bar\User',
+  );
+  $items['file'] = array(
+    'entity_type' => 'file',
+    'bundle' => 'image',
+    'class' => '\Drupal\custom_module\File\Image',
+  );
+
+  return $items;
+}


### PR DESCRIPTION
I'm totally on board with having a _convention_ for naming typed entity classes. But, I think relying on magic naming is a little sketchy, especially as it's in the global name space.

A few ideas:
- Use some sort of registration for Typed entities, instead of magic naming. Something to keep in mind is making sure method autocomplete works, which I don't think it will in the current scenario without manual generation of a metadata file in PHPStorm. Possible ideas:
  - YAML file with mappings
  - Annotations ala Drupal 8
  - Additional lines in the module .info file
  - A raw info hook array.
  - Removing the class entirely, and assuming calling code will know to call `new WhateverTheClassNameIs` directly.
- Perhaps we could use namespaces instead? `\Drupal\typed_entity\Node\Article` for example, where each class under the entity type is the bundle name?
