### PR TITLE
Fix typos

### DIFF
--- a/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleUnitTestCase.php
+++ b/modules/typed_entity_example/lib/Drupal/typed_entity_example/Tests/TypedEntityExampleUnitTestCase.php
@@ -93,9 +93,9 @@ class TypedEntityExampleUnitTestCase extends \DrupalUnitTestCase {
     }
 
     // Test the fallback to TypedEntity.
-    $wrapper_service->setFixturePath(__DIR__ . '/fixtures/page.inc');
+    $wrapper_service->setFixturePath(__DIR__ . '/fixtures/user.inc');
     // Get the mock entity to be loaded.
-    $entity = $wrapper_service->wrap('node', NULL)->value();
+    $entity = $wrapper_service->wrap('user', NULL)->value();
     $typed_user = TypedEntityManager::create('user', $entity);
     $reflection_user = new \ReflectionClass($typed_user);
     if ($reflection_user->name == 'Drupal\typed_entity\TypedEntity\TypedEntity') {

--- a/modules/typed_entity_example/src/TypedEntity/Node/Article.php
+++ b/modules/typed_entity_example/src/TypedEntity/Node/Article.php
@@ -32,7 +32,7 @@ class Article extends TypedNode implements ArticleInterface {
     }
     $item = reset($items);
     $file_id = $item['fid'];
-    return TypedEntityManager::create('user', entity_load_single('file', $file_id));
+    return TypedEntityManager::create('file', entity_load_single('file', $file_id));
   }
 
   /**

--- a/modules/typed_entity_example/src/TypedEntity/Node/ArticleInterface.php
+++ b/modules/typed_entity_example/src/TypedEntity/Node/ArticleInterface.php
@@ -13,10 +13,10 @@ use Drupal\typed_entity_example\TypedEntity\TypedNodeInterface;
 interface ArticleInterface extends TypedNodeInterface {
 
   /**
-   * Gets the author of the node.
+   * Gets the image of the node.
    *
    * @return TypedEntityInterface
-   *   The fully loaded user object.
+   *   The fully loaded image object.
    */
   public function getImage();
 


### PR DESCRIPTION
I found a few typos. Given that in both cases, the typed class fallbacks to _Drupal\typed_entity\TypedEntity\TypedEntity_ tests and example page still working.

Or maybe this is some kind of hidden feature :)

Regards 
